### PR TITLE
Enhance IoWitPackage typing and related types

### DIFF
--- a/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/KotlinGeneratorTest.kt
+++ b/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/KotlinGeneratorTest.kt
@@ -2,7 +2,7 @@ package dev.wasmo.brevity.kotlin.generator
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import dev.wasmo.brevity.io.IoWitPackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
 import dev.wasmo.brevity.io.toWitFile
 import dev.wasmo.brevity.ir.IrMapper
 import dev.wasmo.brevity.toPackageName
@@ -12,7 +12,7 @@ import okio.Path.Companion.toPath
 class KotlinGeneratorTest {
   @Test
   fun `full interface`() {
-    val ioPackage = IoWitPackage(
+    val ioPackage = IoToplevelWitPackage(
       packageName = "wasi:clocks@0.2.12".toPackageName(),
       files = mapOf(
         "clock.wit".toPath() to """
@@ -190,7 +190,7 @@ class KotlinGeneratorTest {
 
   @Test
   fun `full world`() {
-    val ioPackage = IoWitPackage(
+    val ioPackage = IoToplevelWitPackage(
       packageName = "wasi:cli@0.3.0".toPackageName(),
       files = mapOf(
         "command.wit".toPath() to """
@@ -335,7 +335,7 @@ class KotlinGeneratorTest {
 
   @Test
   fun `world function`() {
-    val ioPackage = IoWitPackage(
+    val ioPackage = IoToplevelWitPackage(
       packageName = "wasi:cli@0.3.0".toPackageName(),
       files = mapOf(
         "command.wit".toPath() to """
@@ -438,7 +438,7 @@ class KotlinGeneratorTest {
   /** We had a bug where we used the wrong package name when following includes across packages. */
   @Test
   fun `imports across packages`() {
-    val cliPackage = IoWitPackage(
+    val cliPackage = IoToplevelWitPackage(
       packageName = "wasi:cli@0.3.0".toPackageName(),
       files = mapOf(
         "command.wit".toPath() to """
@@ -450,7 +450,7 @@ class KotlinGeneratorTest {
           """.trimMargin().toWitFile(),
       ),
     )
-    val clockPackage = IoWitPackage(
+    val clockPackage = IoToplevelWitPackage(
       packageName = "wasi:clocks@0.3.0".toPackageName(),
       files = mapOf(
         "clock.wit".toPath() to """
@@ -529,7 +529,7 @@ class KotlinGeneratorTest {
    */
   @Test
   fun `imports of interfaces without functions are skipped`() {
-    val socketsPackage = IoWitPackage(
+    val socketsPackage = IoToplevelWitPackage(
       packageName = "wasi:sockets@0.3.0".toPackageName(),
       files = mapOf(
         "sockets.wit".toPath() to """

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/IoDeclarations.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/IoDeclarations.kt
@@ -10,11 +10,11 @@ import okio.Path
 /**
  * A collection of `.wit` files from a single file system directory.
  */
-data class IoWitPackage(
-  val packageDocumentation: Documentation? = null,
-  val packageName: PackageName,
+data class IoToplevelWitPackage(
+  override val documentation: Documentation? = null,
+  override val packageName: PackageName,
   val files: Map<Path, IoWitFile>,
-)
+): IoWitPackage
 
 data class IoWitFile(
   val packageDocumentation: Documentation? = null,
@@ -28,6 +28,11 @@ sealed interface IoDeclaration {
   val documentation: Documentation?
   val gate: Gate?
   val offset: Offset
+}
+
+sealed interface IoWitPackage {
+  val documentation: Documentation?
+  val packageName: PackageName
 }
 
 sealed interface IoTypeDeclaration : IoDeclaration, IoInterface.Item, IoWorld.Item {
@@ -47,9 +52,9 @@ data class IoInlinePackage(
   override val documentation: Documentation? = null,
   override val gate: Gate? = null,
   override val offset: Offset,
-  val name: PackageName,
+  override val packageName: PackageName,
   val declarations: List<IoWitFile.Item>,
-) : IoDeclaration, IoWitFile.Item
+) : IoDeclaration, IoWitFile.Item, IoWitPackage
 
 /**
  * Declarations may be:

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/IoWitPackageReader.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/IoWitPackageReader.kt
@@ -15,7 +15,7 @@ import okio.Path
 class IoWitPackageReader(
   private val fileSystem: FileSystem,
 ) {
-  fun read(directory: Path): IoWitPackage {
+  fun read(directory: Path): IoToplevelWitPackage {
     val files = mutableMapOf<Path, IoWitFile>()
     for (path in fileSystem.list(directory)) {
       if (!path.name.endsWith(".wit", ignoreCase = true)) continue
@@ -47,8 +47,8 @@ class IoWitPackageReader(
       }
     }
 
-    return IoWitPackage(
-      packageDocumentation = files.values.mapNotNull { it.packageDocumentation }.concatenate(),
+    return IoToplevelWitPackage(
+      documentation = files.values.mapNotNull { it.packageDocumentation }.concatenate(),
       packageName = packageNames.single(),
       files = files,
     )

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/WitFileReader.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/WitFileReader.kt
@@ -69,7 +69,7 @@ internal class WitFileReader(
 
     return IoWitFile(
       packageDocumentation = packageIdentifier?.documentation,
-      packageName = packageIdentifier?.name,
+      packageName = packageIdentifier?.packageName,
       items = items,
     )
   }
@@ -123,7 +123,7 @@ internal class WitFileReader(
       documentation = documentation,
       gate = gate,
       offset = offset,
-      name = name,
+      packageName = name,
       declarations = declarations,
     ) to packageKind
   }

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/ir/IrMapper.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/ir/IrMapper.kt
@@ -24,13 +24,13 @@ import dev.wasmo.brevity.io.IoTypeDeclaration
 import dev.wasmo.brevity.io.IoTypeName
 import dev.wasmo.brevity.io.IoUse
 import dev.wasmo.brevity.io.IoVariant
-import dev.wasmo.brevity.io.IoWitPackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
 import dev.wasmo.brevity.io.IoWorld
 import dev.wasmo.brevity.io.Keywords
 import dev.wasmo.brevity.io.UsePath
 
 class IrMapper(
-  private val packages: List<IoWitPackage>,
+  private val packages: List<IoToplevelWitPackage>,
 ) {
   private val packageNameToPackage = packages.associateBy { it.packageName }
   private val irPackages = mutableMapOf<PackageName, PackageBuilder>()
@@ -59,7 +59,7 @@ class IrMapper(
     }
   }
 
-  private fun addPackage(ioPackage: IoWitPackage) {
+  private fun addPackage(ioPackage: IoToplevelWitPackage) {
     val builder = irPackages.getOrPut(ioPackage.packageName) { PackageBuilder() }
 
     for ((_, ioFile) in ioPackage.files) {

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/IoWitPackageReaderTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/IoWitPackageReaderTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertFailsWith
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
-class IoWitPackageReaderTest {
+class IoToplevelWitPackageReaderTest {
   @Test
   fun happyPath() {
     val directory = "/my-package".toPath()
@@ -53,8 +53,8 @@ class IoWitPackageReaderTest {
     val ioWitPackage = packageReader.read(directory)
 
     assertThat(ioWitPackage).isEqualTo(
-      IoWitPackage(
-        packageDocumentation = Documentation(" command line interfaces!"),
+      IoToplevelWitPackage(
+        documentation = Documentation(" command line interfaces!"),
         packageName = "wasi:cli".toPackageName(),
         files = mapOf(
           "command.wit".toPath() to IoWitFile(

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/WitFileReaderTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/WitFileReaderTest.kt
@@ -1278,7 +1278,7 @@ class WitFileReaderTest {
             documentation = Documentation(" This package is pasted from somewhere else."),
             gate = Gate(since = "1.0"),
             offset = Offset(3, 1),
-            name = "local:a".toPackageName(),
+            packageName = "local:a".toPackageName(),
             declarations = listOf(
               IoInterface(
                 documentation = " This interface is included in a package.",
@@ -1338,7 +1338,7 @@ class WitFileReaderTest {
         items = listOf(
           IoInlinePackage(
             offset = Offset(1, 1),
-            name = "local:a".toPackageName(),
+            packageName = "local:a".toPackageName(),
             declarations = listOf(
               IoTopLevelUse(
                 documentation = Documentation(" Use the Wasi HTTP types."),
@@ -1368,7 +1368,7 @@ class WitFileReaderTest {
         items = listOf(
           IoInlinePackage(
             offset = Offset(1, 1),
-            name = "local:a".toPackageName(),
+            packageName = "local:a".toPackageName(),
             declarations = listOf(
               IoWorld(
                 documentation = " a printer-scanner-fax thingy",

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/ir/IrMapperTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/ir/IrMapperTest.kt
@@ -10,7 +10,7 @@ import dev.wasmo.brevity.FunctionName
 import dev.wasmo.brevity.Identifier
 import dev.wasmo.brevity.Offset
 import dev.wasmo.brevity.io.IoTypeName
-import dev.wasmo.brevity.io.IoWitPackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
 import dev.wasmo.brevity.io.toUsePath
 import dev.wasmo.brevity.io.toWitFile
 import dev.wasmo.brevity.toPackageName
@@ -22,7 +22,7 @@ class IrMapperTest {
   @Test
   fun `find local symbols`() {
     val ioPackages = listOf(
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:clocks".toPackageName(),
         files = mapOf(
           "clock.wit".toPath() to """
@@ -67,7 +67,7 @@ class IrMapperTest {
   @Test
   fun `find symbols across packages with use`() {
     val ioPackages = listOf(
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:cli".toPackageName(),
         files = mapOf(
           "stdio.wit".toPath() to """
@@ -79,7 +79,7 @@ class IrMapperTest {
             """.trimMargin().toWitFile(),
         ),
       ),
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:io@0.2.12".toPackageName(),
         files = mapOf(
           "streams.wit".toPath() to """
@@ -114,7 +114,7 @@ class IrMapperTest {
   @Test
   fun `imports across packages`() {
     val ioPackages = listOf(
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:cli@0.3.0".toPackageName(),
         files = mapOf(
           "command.wit".toPath() to """
@@ -133,7 +133,7 @@ class IrMapperTest {
             """.trimMargin().toWitFile(),
         ),
       ),
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:clocks@0.3.0".toPackageName(),
         files = mapOf(
           "world.wit".toPath() to """
@@ -243,7 +243,7 @@ class IrMapperTest {
   @Test
   fun `find symbols in same package with use`() {
     val ioPackages = listOf(
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:clocks@0.2.12".toPackageName(),
         files = mapOf(
           "timezone.wit".toPath() to """
@@ -286,7 +286,7 @@ class IrMapperTest {
 
   @Test
   fun `get world`() {
-    val wasiCli = IoWitPackage(
+    val wasiCli = IoToplevelWitPackage(
       packageName = "wasi:cli@0.2.12".toPackageName(),
       files = mapOf(
         "command.wit".toPath() to """
@@ -297,7 +297,7 @@ class IrMapperTest {
           """.trimMargin().toWitFile(),
       ),
     )
-    val wasiIo = IoWitPackage(
+    val wasiIo = IoToplevelWitPackage(
       packageName = "wasi:io@0.2.12".toPackageName(),
       files = mapOf(
         "world.wit".toPath() to """
@@ -323,7 +323,7 @@ class IrMapperTest {
   @Test
   fun `interface function abi names`() {
     val ioPackages = listOf(
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:clocks@0.3.0".toPackageName(),
         files = mapOf(
           "system-clock.wit".toPath() to """
@@ -351,7 +351,7 @@ class IrMapperTest {
   @Test
   fun `resource function abi names`() {
     val ioPackages = listOf(
-      IoWitPackage(
+      IoToplevelWitPackage(
         packageName = "wasi:http@0.3.0".toPackageName(),
         files = mapOf(
           "types.wit".toPath() to """

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/ir/WorldFlattenerTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/ir/WorldFlattenerTest.kt
@@ -8,7 +8,7 @@ import dev.wasmo.brevity.io.IoFunction
 import dev.wasmo.brevity.io.IoInclude
 import dev.wasmo.brevity.io.IoInterface
 import dev.wasmo.brevity.io.IoWitFile
-import dev.wasmo.brevity.io.IoWitPackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
 import dev.wasmo.brevity.io.IoWorld
 import dev.wasmo.brevity.toPackageName
 import kotlin.test.Test
@@ -50,7 +50,7 @@ class WorldFlattenerTest {
       ),
     )
 
-    val wasiCommand = IoWitPackage(
+    val wasiCommand = IoToplevelWitPackage(
       packageName = "wasi:cli@0.3.0".toPackageName(),
       files = mapOf(
         "command.wit".toPath() to IoWitFile(


### PR DESCRIPTION
Toplevel and inline packages can't collide with one another, but having a common parent type allows writing the validation code once against both.

I only did as much of this as was necessary for validating name collisions.