### PR TITLE
Filter output to only named worlds

### DIFF
--- a/.buildkite/build.yml
+++ b/.buildkite/build.yml
@@ -2,7 +2,7 @@ steps:
   - label: ":gradle: Build"
     commands:
       - "cat .buildkite/gradle.properties >> gradle.properties"
-      - "gradle jvmTest"
+      - "gradle check"
     plugins:
       - docker#v5.13.0:
           image: wasmo/brevity-ci@sha256:62dff340c59e68caff71be91045918ae84f2c95b414a1fa385d92c5503157f88

--- a/brevity-cli/src/main/kotlin/dev/wasmo/brevity/cli/BrevityCommand.kt
+++ b/brevity-cli/src/main/kotlin/dev/wasmo/brevity/cli/BrevityCommand.kt
@@ -3,6 +3,7 @@ package dev.wasmo.brevity.cli
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
+import okio.FileSystem
 
 class BrevityCommand : CliktCommand(
   name = "brevity",
@@ -11,5 +12,5 @@ class BrevityCommand : CliktCommand(
 }
 
 fun main(args: Array<String>) = BrevityCommand()
-  .subcommands(GenerateKotlinCommand())
+  .subcommands(GenerateKotlinCommand(FileSystem.SYSTEM))
   .main(args)

--- a/brevity-cli/src/main/kotlin/dev/wasmo/brevity/cli/Clikt.kt
+++ b/brevity-cli/src/main/kotlin/dev/wasmo/brevity/cli/Clikt.kt
@@ -1,0 +1,36 @@
+package dev.wasmo.brevity.cli
+
+import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.parameters.options.NullableOption
+import com.github.ajalt.clikt.parameters.options.RawOption
+import com.github.ajalt.clikt.parameters.options.convert
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+fun RawOption.okioReadableDirectory(
+  fileSystem: FileSystem,
+): NullableOption<Path, Path> {
+  return convert({ localization.pathMetavar() }, CompletionCandidates.Path) { string ->
+    string.toPath()
+      .also { path ->
+        if (fileSystem.metadataOrNull(path)?.isDirectory != true) {
+          throw BadParameterValue("not a readable directory: $path", option, name)
+        }
+      }
+  }
+}
+
+fun RawOption.okioWritableDirectory(
+  fileSystem: FileSystem,
+): NullableOption<Path, Path> {
+  return convert({ localization.pathMetavar() }, CompletionCandidates.Path) { string ->
+    string.toPath()
+      .also { path ->
+        if (fileSystem.metadataOrNull(path)?.isDirectory == false) {
+          throw BadParameterValue("not a writable directory: $path", option, name)
+        }
+      }
+  }
+}

--- a/brevity-cli/src/main/kotlin/dev/wasmo/brevity/cli/GenerateKotlinCommand.kt
+++ b/brevity-cli/src/main/kotlin/dev/wasmo/brevity/cli/GenerateKotlinCommand.kt
@@ -5,43 +5,49 @@ import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
-import com.github.ajalt.clikt.parameters.types.path
+import dev.wasmo.brevity.filterNamedWorlds
 import dev.wasmo.brevity.io.IoWitPackageReader
 import dev.wasmo.brevity.ir.IrMapper
 import dev.wasmo.brevity.kotlin.generator.ApiGenerator
 import dev.wasmo.brevity.kotlin.generator.GuestGenerator
 import dev.wasmo.brevity.kotlin.generator.HostGenerator
 import dev.wasmo.brevity.kotlin.generator.KtMapper
-import java.nio.file.Path
 import okio.FileSystem
-import okio.Path.Companion.toOkioPath
+import okio.Path
 
-class GenerateKotlinCommand : CliktCommand(
+class GenerateKotlinCommand(
+  private val fileSystem: FileSystem,
+) : CliktCommand(
   name = "generate-kotlin",
 ) {
   val inputWitDirectories: List<Path> by option("--wit")
-    .path(mustExist = true, canBeFile = false, canBeDir = true)
+    .okioReadableDirectory(fileSystem)
     .multiple(required = true)
     .help("each directory should contain a single package")
   val outputKotlinCommonMain: Path by option("--commonMain")
-    .path(canBeFile = false, canBeDir = true)
+    .okioWritableDirectory(fileSystem)
     .required()
   val outputKotlinWasmWasiMain: Path by option("--wasmWasiMain")
-    .path(canBeFile = false, canBeDir = true)
+    .okioWritableDirectory(fileSystem)
     .required()
   val outputKotlinJvmMain: Path by option("--jvmMain")
-    .path(canBeFile = false, canBeDir = true)
+    .okioWritableDirectory(fileSystem)
     .required()
+  val world: List<String> by option("--world")
+    .multiple()
+    .help("the world name like 'command', 'wasi:cli/command', or 'wasi:cli/command@0.3.0'")
 
   override fun run() {
-    val packageReader = IoWitPackageReader(FileSystem.SYSTEM)
-    val ktMapper = KtMapper(onlyLongs = true)
+    val packageReader = IoWitPackageReader(fileSystem)
+    val ktMapper = KtMapper(
+      onlyLongs = true,
+    )
     val apiGenerator = ApiGenerator()
     val guestGenerator = GuestGenerator()
     val hostGenerator = HostGenerator()
 
     val ioWitPackages = inputWitDirectories.map {
-      packageReader.read(it.toOkioPath())
+      packageReader.read(it)
     }
 
     val commonMainDir = outputKotlinCommonMain.toFile()
@@ -53,7 +59,13 @@ class GenerateKotlinCommand : CliktCommand(
     val jvmMainDir = outputKotlinJvmMain.toFile()
     jvmMainDir.mkdirs()
 
-    val irPackages = IrMapper(ioWitPackages).map()
+    val allIrPackages = IrMapper(ioWitPackages).map()
+
+    val irPackages = when {
+      world.isEmpty() -> allIrPackages
+      else -> allIrPackages.filterNamedWorlds(world)
+    }
+
     for (irPackage in irPackages) {
       val ktPackage = ktMapper.map(irPackage)
 

--- a/brevity-gradle-plugin/src/main/kotlin/dev/wasmo/brevity/gradle/BrevityTask.kt
+++ b/brevity-gradle-plugin/src/main/kotlin/dev/wasmo/brevity/gradle/BrevityTask.kt
@@ -4,9 +4,11 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.IgnoreEmptyDirectories
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
@@ -29,6 +31,10 @@ abstract class BrevityTask : DefaultTask() {
   @get:IgnoreEmptyDirectories
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val inputWitPackageDirectories: ConfigurableFileCollection
+
+  /** World names like 'command', 'wasi:cli/command', or 'wasi:cli/command@0.3.0' */
+  @get:Input
+  abstract val worlds: ListProperty<String>
 
   @get:OutputDirectory
   internal abstract val outputKotlinCommonMain: DirectoryProperty
@@ -61,6 +67,10 @@ abstract class BrevityTask : DefaultTask() {
         add(outputKotlinWasmWasiMain.get().asFile.path)
         add("--jvmMain")
         add(outputKotlinJvmMain.get().asFile.path)
+        for (world in worlds.get()) {
+          add("--world")
+          add(world)
+        }
       }
     }
   }

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/KtMapper.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/KtMapper.kt
@@ -23,7 +23,6 @@ import dev.wasmo.brevity.ir.IrWorld
  */
 class KtMapper(
   private val kotlinPackagePrefix: String = "wit",
-  private val worldFilter: (IrWorld) -> Boolean = { true },
   private val onlyLongs: Boolean = false,
 ) {
   private val typeMapper = TypeMapper(kotlinPackagePrefix)
@@ -178,8 +177,6 @@ class KtMapper(
 
   context(context: Context)
   internal fun IrWorld.worldToKt(): KtWorld? {
-    if (!worldFilter.invoke(this)) return null
-
     val kotlinName = context.kotlinName + name
     val hostName = kotlinName + Identifier("Host")
     val guestName = kotlinName + Identifier("Guest")

--- a/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/KotlinGeneratorTest.kt
+++ b/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/KotlinGeneratorTest.kt
@@ -2,6 +2,7 @@ package dev.wasmo.brevity.kotlin.generator
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import dev.wasmo.brevity.filterNamedWorlds
 import dev.wasmo.brevity.io.IoToplevelWitPackage
 import dev.wasmo.brevity.io.toWitFile
 import dev.wasmo.brevity.ir.IrMapper
@@ -225,10 +226,10 @@ class KotlinGeneratorTest {
       ),
     )
 
-    val irPackage = IrMapper(listOf(ioPackage)).map().single()
-    val ktPackage = KtMapper(
-      worldFilter = { world -> world.name.name == "command" },
-    ).map(irPackage)
+    val irPackage = IrMapper(listOf(ioPackage)).map()
+      .filterNamedWorlds(listOf("command"))
+      .single()
+    val ktPackage = KtMapper().map(irPackage)
 
     assertThat(ApiGenerator().generate(ktPackage).toString()).isEqualTo(
       """
@@ -346,10 +347,10 @@ class KotlinGeneratorTest {
       ),
     )
 
-    val irPackage = IrMapper(listOf(ioPackage)).map().single()
-    val ktPackage = KtMapper(
-      worldFilter = { world -> world.name.name == "command" },
-    ).map(irPackage)
+    val irPackage = IrMapper(listOf(ioPackage)).map()
+      .filterNamedWorlds(listOf("command"))
+      .single()
+    val ktPackage = KtMapper().map(irPackage)
 
     assertThat(ApiGenerator().generate(ktPackage).toString()).isEqualTo(
       """

--- a/brevity-wasi/build.gradle.kts
+++ b/brevity-wasi/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 
 brevity {
   generateKotlin {
+    worlds.add("wasi:http/service@0.3.0")
     inputWitPackageDirectories.from(
       File(project.rootDir, "submodules/WASI/proposals/cli/wit"),
       File(project.rootDir, "submodules/WASI/proposals/clocks/wit"),

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/WorldFilter.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/WorldFilter.kt
@@ -1,0 +1,56 @@
+package dev.wasmo.brevity
+
+import dev.wasmo.brevity.ir.IrParentName
+import dev.wasmo.brevity.ir.IrWitPackage
+import dev.wasmo.brevity.ir.IrWorld
+import java.util.TreeSet
+
+/**
+ * Returns a copy of [this] containing only the worlds named in [worldNames].
+ *
+ * @throws IllegalArgumentException if any name in [worldNames] doesn't identify a world.
+ */
+fun Collection<IrWitPackage>.filterNamedWorlds(
+  worldNames: Collection<String>,
+): List<IrWitPackage> {
+  val leftoverWorldNames = worldNames.toMutableList()
+  val acceptableWorldNames = TreeSet<String>()
+
+  val result = map { irPackage ->
+    irPackage.copy(
+      items = irPackage.items.filter { item ->
+        when (item) {
+          is IrWorld -> {
+            val itemAcceptableWorldNames = worldNames(irPackage.packageName, item)
+            acceptableWorldNames += itemAcceptableWorldNames
+
+            // Returns true if this world name matches.
+            leftoverWorldNames.removeAll(itemAcceptableWorldNames)
+          }
+
+          else -> true
+        }
+      },
+    )
+  }
+
+  require(leftoverWorldNames.isEmpty()) {
+    """
+    |unexpected world name:
+    |  ${leftoverWorldNames.joinToString(separator = "\n  ")}
+    |not in acceptable set:
+    |  ${acceptableWorldNames.joinToString(separator = "\n  ")}
+    """.trimMargin()
+  }
+
+  return result
+}
+
+/** Returns all acceptable names for [irWorld]. */
+fun worldNames(packageName: PackageName, irWorld: IrWorld): Set<String> {
+  return setOf(
+    irWorld.name.name,
+    IrParentName(packageName, irWorld.name).toString(),
+    IrParentName(packageName.copy(version = null), irWorld.name).toString(),
+  )
+}

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/WorldFilterTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/WorldFilterTest.kt
@@ -1,0 +1,69 @@
+package dev.wasmo.brevity
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
+import dev.wasmo.brevity.io.toWitFile
+import dev.wasmo.brevity.ir.IrMapper
+import dev.wasmo.brevity.ir.IrWorld
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import okio.Path.Companion.toPath
+
+class WorldFilterTest {
+  private val ioPackages = listOf(
+    IoToplevelWitPackage(
+      packageName = "wasi:cli@0.3.0".toPackageName(),
+      files = mapOf(
+        "command.wit".toPath() to """
+          |package wasi:cli@0.3.0;
+          |
+          |world command {
+          |}
+          """.trimMargin().toWitFile(),
+        "imports.wit".toPath() to """
+          |package wasi:cli@0.3.0;
+          |
+          |world imports {
+          |}
+          """.trimMargin().toWitFile(),
+      ),
+    ),
+  )
+
+  @Test
+  fun filterSuccess() {
+    val irPackages = IrMapper(ioPackages).map()
+    val commandWorld = irPackages.single().items.single {
+      (it as? IrWorld)?.name?.name == "command"
+    }
+
+    assertThat(irPackages.filterNamedWorlds(listOf("command")).single().items)
+      .containsExactly(commandWorld)
+    assertThat(irPackages.filterNamedWorlds(listOf("wasi:cli/command")).single().items)
+      .containsExactly(commandWorld)
+    assertThat(irPackages.filterNamedWorlds(listOf("wasi:cli/command@0.3.0")).single().items)
+      .containsExactly(commandWorld)
+  }
+
+  @Test
+  fun filterDoesntMatch() {
+    val irPackages = IrMapper(ioPackages).map()
+
+    val e = assertFailsWith<IllegalArgumentException> {
+      irPackages.filterNamedWorlds(listOf("wasi:command"))
+    }
+    assertThat(e).hasMessage("""
+      |unexpected world name:
+      |  wasi:command
+      |not in acceptable set:
+      |  command
+      |  imports
+      |  wasi:cli/command
+      |  wasi:cli/command@0.3.0
+      |  wasi:cli/imports
+      |  wasi:cli/imports@0.3.0
+      """.trimMargin())
+  }
+}

--- a/docs/development/buildkite_ci.md
+++ b/docs/development/buildkite_ci.md
@@ -53,7 +53,7 @@ $ docker run \
   --volume .:/workdir \
   --workdir /workdir \
   wasmo/brevity-ci \
-  gradle :jvmTest -Pbrevity.build.environment=ci
+  gradle check -Pbrevity.build.environment=ci
 ```
 
 Consider keeping a separate clone of the Brevity repo for doing Linux x64 builds. Our Gradle plugins


### PR DESCRIPTION
Previously I was generating two worlds for HTTP, 'service' and 'middleware' and these conflicted.