### PR TITLE
Create WitPackageNamingValidator

### DIFF
--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/validation/validations.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/validation/validations.kt
@@ -1,0 +1,36 @@
+package dev.wasmo.brevity.io.validation
+
+import dev.wasmo.brevity.PackageName
+import dev.wasmo.brevity.WitException
+import dev.wasmo.brevity.io.IoInlinePackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
+import dev.wasmo.brevity.io.IoWitPackage
+
+fun validateUniquePackageNames(toplevelPackages: List<IoToplevelWitPackage>): Map<PackageName, IoWitPackage> {
+  val collisions = mutableMapOf<PackageName, MutableList<IoWitPackage>>()
+  return buildMap {
+    val inlinePackages = toplevelPackages.flatMap { toplevel ->
+      toplevel.files.values.flatMap { file ->
+        file.items.filterIsInstance<IoInlinePackage>()
+      }
+    }
+    for (pkg in toplevelPackages + inlinePackages) {
+      val existing = this[pkg.packageName]
+      if (existing != null) {
+        val collisionsList = collisions[pkg.packageName] ?: mutableListOf(existing).also {
+          collisions[pkg.packageName] = it
+        }
+
+        collisionsList.add(pkg)
+      } else {
+        this[pkg.packageName] = pkg
+      }
+    }
+    // Just blow up on the first collision for now.
+    collisions.entries.firstOrNull()?.let { (packageName, _) ->
+      throw WitException(
+        "Duplicate package definitions for $packageName",
+      )
+    }
+  }
+}

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidationTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidationTest.kt
@@ -1,0 +1,76 @@
+package dev.wasmo.brevity.io.validation
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEqualTo
+import dev.wasmo.brevity.Offset
+import dev.wasmo.brevity.io.IoInlinePackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
+import dev.wasmo.brevity.io.IoWitFile
+import dev.wasmo.brevity.toPackageName
+import kotlin.test.assertFailsWith
+import okio.Path
+import okio.Path.Companion.toPath
+import org.junit.Test
+
+class ValidationTest {
+  @Test
+  fun producesPackageNameMapWhenSuccessful() {
+    val cliPackage = IoToplevelWitPackage(
+      packageName = "wasi:cli".toPackageName(),
+      files = emptyMap()
+    )
+    val inlinePackage = IoInlinePackage(
+      packageName = "wasi:inline".toPackageName(),
+      offset = Offset(1, 2),
+      declarations = emptyList(),
+    )
+    val otherPackage = IoToplevelWitPackage(
+      packageName = "wasi:other".toPackageName(),
+      files = mapOf(
+        "other.wit".toPath() to IoWitFile(
+          items = listOf(
+            inlinePackage
+          )
+        )
+      )
+    )
+    val packages = listOf(cliPackage, otherPackage)
+
+    val map = validateUniquePackageNames(packages)
+
+    assertThat(map).containsOnly(
+      "wasi:cli".toPackageName() to cliPackage,
+      "wasi:inline".toPackageName() to inlinePackage,
+      "wasi:other".toPackageName() to otherPackage,
+    )
+  }
+
+  @Test
+  fun throwsOnCollision() {
+    val cliPackage = IoToplevelWitPackage(
+      packageName = "wasi:cli".toPackageName(),
+      files = emptyMap()
+    )
+    val inlinePackage = IoInlinePackage(
+      packageName = "wasi:cli".toPackageName(),
+      offset = Offset(1, 2),
+      declarations = emptyList(),
+    )
+    val otherPackage = IoToplevelWitPackage(
+      packageName = "wasi:other".toPackageName(),
+      files = mapOf(
+        "other.wit".toPath() to IoWitFile(
+          items = listOf(
+            inlinePackage
+          )
+        )
+      )
+    )
+    val exception = assertFailsWith<Exception> {
+      validateUniquePackageNames(listOf(cliPackage, otherPackage))
+    }
+
+    assertThat(exception.message).isEqualTo("Duplicate package definitions for wasi:cli")
+  }
+}


### PR DESCRIPTION
Erroring could be better here. 

Been a few weeks since I looked at this; I was thinking as I wrote it that the output of this particular validation is actually a 1:1 map of package names to their sites. But I've lost a lot of the context of what I was thinking about that, other than that I was also thinking about the pattern of using context params to pass around an error reporter. 