### PR TITLE
Add validateUniqueServiceNames

### DIFF
--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/ServiceName.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/ServiceName.kt
@@ -1,5 +1,6 @@
 package dev.wasmo.brevity
 
+import dev.wasmo.brevity.io.IoDeclaration
 import dev.wasmo.brevity.io.UsePath
 
 /**

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/IoDeclarations.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/IoDeclarations.kt
@@ -30,6 +30,11 @@ sealed interface IoDeclaration {
   val offset: Offset
 }
 
+sealed interface IoService: IoDeclaration {
+  val name: Identifier
+}
+
+
 sealed interface IoWitPackage {
   val documentation: Documentation?
   val packageName: PackageName
@@ -73,9 +78,9 @@ data class IoInterface(
   override val documentation: Documentation? = null,
   override val gate: Gate? = null,
   override val offset: Offset,
-  val name: Identifier,
+  override val name: Identifier,
   val items: List<Item>,
-) : IoDeclaration, IoWorld.Api, IoWitFile.Item {
+) : IoDeclaration, IoService, IoWorld.Api, IoWitFile.Item {
   sealed interface Item : IoDeclaration
 }
 
@@ -83,11 +88,11 @@ data class IoWorld(
   override val documentation: Documentation? = null,
   override val gate: Gate? = null,
   override val offset: Offset,
-  val name: Identifier,
+  override val name: Identifier,
   val items: List<Item>,
   val imports: List<Api>,
   val exports: List<Api>,
-) : IoDeclaration, IoWitFile.Item {
+) : IoDeclaration, IoService, IoWitFile.Item {
   sealed interface Api : IoDeclaration
   sealed interface Item : IoDeclaration
 }

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/validation/validations.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/validation/validations.kt
@@ -2,13 +2,18 @@ package dev.wasmo.brevity.io.validation
 
 import dev.wasmo.brevity.Offset
 import dev.wasmo.brevity.PackageName
+import dev.wasmo.brevity.ServiceName
 import dev.wasmo.brevity.WitCompoundException
 import dev.wasmo.brevity.WitMultiplySitedException
 import dev.wasmo.brevity.WitMultiplySitedException.Location
 import dev.wasmo.brevity.io.IoInlinePackage
+import dev.wasmo.brevity.io.IoInterface
+import dev.wasmo.brevity.io.IoService
+import dev.wasmo.brevity.io.IoTopLevelUse
 import dev.wasmo.brevity.io.IoToplevelWitPackage
 import dev.wasmo.brevity.io.IoWitFile
 import dev.wasmo.brevity.io.IoWitPackage
+import dev.wasmo.brevity.io.IoWorld
 import okio.Path
 import okio.Path.Companion.toPath
 
@@ -79,6 +84,73 @@ sealed interface PackageRef {
     override val offset = pkg.offset
   }
 }
+
+fun validateUniqueServiceNames(toplevelPackages: List<IoToplevelWitPackage>): Map<ServiceName, IoService> {
+  val serviceRefs = mutableMapOf<ServiceName, MutableList<ServiceRef>>()
+
+  val addService: (ServiceName, ServiceRef)->Unit = { serviceName, service ->
+    serviceRefs.getOrPut(serviceName) { mutableListOf() }.add(service)
+  }
+  for (pkg in toplevelPackages) {
+    for ((path, file) in pkg.files) {
+      for (item in file.items) {
+        when (item) {
+          is IoInlinePackage -> processInlinePackage(path, item, addService)
+          is IoInterface, is IoWorld -> addService(
+            ServiceName(pkg.packageName, item.name),
+            ServiceRef(path, item),
+          )
+          is IoTopLevelUse -> {}
+        }
+      }
+    }
+  }
+  val collisions = mutableMapOf<ServiceName, List<ServiceRef>>()
+  val output = mutableMapOf<ServiceName, IoService>()
+
+  for ((serviceName, serviceRefs) in serviceRefs) {
+    when (serviceRefs.size) {
+      0 -> error("Invariant violated: service name exists without reference")
+      1 -> output[serviceName] = serviceRefs.single().service
+      else -> {
+        output[serviceName] = serviceRefs.first().service
+        collisions[serviceName] = serviceRefs
+      }
+    }
+  }
+
+  val collisionExceptions = collisions.map { (serviceName, serviceRefs) ->
+    WitMultiplySitedException("Duplicate definitions of $serviceName", serviceRefs.map { serviceRef ->
+      Location(serviceRef.path.toString(), serviceRef.service.offset)
+    }.toList())
+  }
+
+  when (collisionExceptions.size) {
+    0 -> {}
+    1 -> throw collisionExceptions.single()
+    else -> throw WitCompoundException(collisionExceptions)
+  }
+
+  return output
+}
+
+private fun processInlinePackage(path: Path, pkg: IoInlinePackage, addService: (ServiceName, ServiceRef)->Unit) {
+  for (decl in pkg.declarations) {
+    when (decl) {
+      is IoInlinePackage -> processInlinePackage(path, decl, addService)
+      is IoInterface, is IoWorld -> addService(
+        ServiceName(pkg.packageName, decl.name),
+        ServiceRef(path, decl),
+      )
+      is IoTopLevelUse -> {}
+    }
+  }
+}
+
+data class ServiceRef(
+  val path: Path,
+  val service: IoService,
+)
 
 private val IoToplevelWitPackage.directory: Path
   get() = files.keys.first().parent ?: "".toPath()

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidateUniquePackageNamesTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidateUniquePackageNamesTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.containsOnly
 import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
 import dev.wasmo.brevity.Offset
 import dev.wasmo.brevity.WitCompoundException
 import dev.wasmo.brevity.WitMultiplySitedException
@@ -17,7 +16,7 @@ import kotlin.test.assertFailsWith
 import okio.Path.Companion.toPath
 import org.junit.Test
 
-class ValidationTest {
+class ValidateUniquePackageNamesTest {
   @Test
   fun producesPackageNameMapWhenSuccessful() {
     val cliPackage = IoToplevelWitPackage(

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidateUniqueServiceNamesTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidateUniqueServiceNamesTest.kt
@@ -1,0 +1,51 @@
+package dev.wasmo.brevity.io.validation
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import dev.wasmo.brevity.Offset
+import dev.wasmo.brevity.io.IoInlinePackage
+import dev.wasmo.brevity.io.IoToplevelWitPackage
+import dev.wasmo.brevity.io.IoWitFile
+import dev.wasmo.brevity.toPackageName
+import okio.Path.Companion.toPath
+import org.junit.Test
+
+class ValidateUniqueServiceNamesTest {
+  @Test
+  fun producesServiceNameMapWhenSuccessful() {
+    val cliPackage = IoToplevelWitPackage(
+      packageName = "wasi:cli".toPackageName(),
+      files = mapOf(
+        "".toPath() to IoWitFile(
+          packageName = "wasi:cli".toPackageName(),
+        )
+      )
+    )
+    val inlinePackage = IoInlinePackage(
+      packageName = "wasi:inline".toPackageName(),
+      offset = Offset(1, 2),
+      declarations = emptyList(),
+    )
+    val otherPackage = IoToplevelWitPackage(
+      packageName = "wasi:other".toPackageName(),
+      files = mapOf(
+        "other/other.wit".toPath() to IoWitFile(
+          packageName = "wasi:other".toPackageName(),
+          items = listOf(
+            inlinePackage
+          )
+        )
+      )
+    )
+    val packages = listOf(cliPackage, otherPackage)
+
+    val map = validateUniquePackageNames(packages)
+
+    assertThat(map).containsOnly(
+      "wasi:cli".toPackageName() to cliPackage,
+      "wasi:inline".toPackageName() to inlinePackage,
+      "wasi:other".toPackageName() to otherPackage,
+    )
+  }
+
+}


### PR DESCRIPTION
Already had this and thought I could get away with doing the revisions to exceptions/issue management before putting it up. I can't! (Not easily, at least)

I figured it makes sense to follow the same pattern as package names - and since we're walking this, why not create a map and use that in the same way on integration?