### PR TITLE
Support guest-provided return pointers

### DIFF
--- a/brevity-integration-tests/build.gradle.kts
+++ b/brevity-integration-tests/build.gradle.kts
@@ -47,7 +47,7 @@ val rustCargoBuild = tasks.register("rustCargoBuild", Exec::class.java) {
   description = "Generate .wasm components from Rust sources"
   workingDir = File(projectDir, "rust")
   commandLine(
-    "cargo", "build",
+    "${environment["HOME"]}/.cargo/bin/cargo", "build",
     "--target=wasm32-wasip2",
     "--release",
   )
@@ -59,7 +59,7 @@ val rustComponentUnbundle = tasks.register("rustComponentUnbundle", Exec::class.
   description = "Unbundle the .wasm component into a .wasm core module"
   workingDir = File(projectDir, "rust")
   commandLine(
-    "wasm-tools", "component", "unbundle",
+    "${environment["HOME"]}/.cargo/bin/wasm-tools", "component", "unbundle",
     "--module-dir", "target/unbundled/",
     "--output", "target/unbundled/component.wasm",
     "./target/wasm32-wasip2/release/wasmo_testing.wasm",

--- a/brevity-integration-tests/build.gradle.kts
+++ b/brevity-integration-tests/build.gradle.kts
@@ -47,7 +47,7 @@ val rustCargoBuild = tasks.register("rustCargoBuild", Exec::class.java) {
   description = "Generate .wasm components from Rust sources"
   workingDir = File(projectDir, "rust")
   commandLine(
-    "${environment["HOME"]}/.cargo/bin/cargo", "build",
+    "cargo", "build",
     "--target=wasm32-wasip2",
     "--release",
   )
@@ -59,7 +59,7 @@ val rustComponentUnbundle = tasks.register("rustComponentUnbundle", Exec::class.
   description = "Unbundle the .wasm component into a .wasm core module"
   workingDir = File(projectDir, "rust")
   commandLine(
-    "${environment["HOME"]}/.cargo/bin/wasm-tools", "component", "unbundle",
+    "wasm-tools", "component", "unbundle",
     "--module-dir", "target/unbundled/",
     "--output", "target/unbundled/component.wasm",
     "./target/wasm32-wasip2/release/wasmo_testing.wasm",

--- a/brevity-integration-tests/src/jvmTest/kotlin/com/wasmo/wasm/RunKotlinWasmTest.kt
+++ b/brevity-integration-tests/src/jvmTest/kotlin/com/wasmo/wasm/RunKotlinWasmTest.kt
@@ -37,7 +37,7 @@ class RunKotlinWasmTest {
   }
 
   @Test
-  fun `call kotlin concatenate`() = runTest {
+  fun `call concatenate`() = runTest {
     val world = WasmoTesting.World { Unit }
     val tester = WasmTester.Builder()
       .wasmPath(WasmSource.Kotlin.path)

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CoreParameter.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CoreParameter.kt
@@ -1,11 +1,7 @@
 package dev.wasmo.brevity.kotlin.generator
 
-import com.squareup.kotlinpoet.NameAllocator
 import com.squareup.kotlinpoet.ParameterSpec
-import dev.wasmo.brevity.Identifier
-import dev.wasmo.brevity.TypeName
 import dev.wasmo.brevity.kotlin.encoders.Encoder
-import dev.wasmo.brevity.kotlin.encoders.EncoderFactory
 
 /**
  * A list of parameters that use core types only, to be lifted on inbound calls and lowered on
@@ -15,35 +11,5 @@ class CoreParameter(
   val encoder: Encoder,
   val specs: List<ParameterSpec>,
   val names: List<String>,
-) {
-  class Factory(
-    val encoderFactory: EncoderFactory,
-    val nameAllocator: NameAllocator,
-  ) {
-    operator fun invoke(name: Identifier, typeName: TypeName): CoreParameter {
-      val encoder = encoderFactory.get(typeName)
-      val nameHints = encoder.nameHints
+)
 
-      val specs = mutableListOf<ParameterSpec>()
-      val names = mutableListOf<String>()
-      for ((index, coreType) in encoder.coreTypes.withIndex()) {
-        val nameHint = nameHints?.getOrNull(index)
-        val coreName = when {
-          nameHint != null -> nameAllocator.newName(
-            Identifier("${name}-${nameHint.name}").toCamelCase(upperCamel = false),
-          )
-
-          else -> nameAllocator[name]
-        }
-        specs += ParameterSpec(coreName, coreType.kotlinCoreType)
-        names += coreName
-      }
-
-      return CoreParameter(
-        encoder = encoder,
-        specs = specs,
-        names = names,
-      )
-    }
-  }
-}

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CoreResult.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CoreResult.kt
@@ -1,0 +1,19 @@
+package dev.wasmo.brevity.kotlin.generator
+
+import com.squareup.kotlinpoet.ParameterSpec
+import dev.wasmo.brevity.TypeName
+import dev.wasmo.brevity.kotlin.encoders.Encoder
+
+/**
+ * A return value for lifting and lowering.
+ */
+class CoreResult(
+  val name: String,
+  val type: TypeName,
+  val encoder: Encoder,
+  /**
+   * Non-null if a host function returns data to a guest-provided pointer, and not a host-allocated
+   * pointer.
+   */
+  val parameter: ParameterSpec?
+)

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CoreValueFactory.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CoreValueFactory.kt
@@ -1,0 +1,58 @@
+package dev.wasmo.brevity.kotlin.generator
+
+import com.squareup.kotlinpoet.NameAllocator
+import com.squareup.kotlinpoet.ParameterSpec
+import dev.wasmo.brevity.Identifier
+import dev.wasmo.brevity.TypeName
+import dev.wasmo.brevity.kotlin.encoders.CoreType
+import dev.wasmo.brevity.kotlin.encoders.EncoderFactory
+
+class CoreValueFactory(
+  val encoderFactory: EncoderFactory,
+  val nameAllocator: NameAllocator,
+) {
+  fun parameter(name: Identifier, typeName: TypeName): CoreParameter {
+    val encoder = encoderFactory.get(typeName)
+    val nameHints = encoder.nameHints
+
+    val specs = mutableListOf<ParameterSpec>()
+    val names = mutableListOf<String>()
+    for ((index, coreType) in encoder.coreTypes.withIndex()) {
+      val nameHint = nameHints?.getOrNull(index)
+      val coreName = when {
+        nameHint != null -> nameAllocator.newName(
+          Identifier("${name}-${nameHint.name}").toCamelCase(upperCamel = false),
+        )
+
+        else -> nameAllocator[name]
+      }
+      specs += ParameterSpec(coreName, coreType.kotlinCoreType)
+      names += coreName
+    }
+
+    return CoreParameter(
+      encoder = encoder,
+      specs = specs,
+      names = names,
+    )
+  }
+
+  fun result(type: TypeName): CoreResult {
+    val encoder = encoderFactory.get(type)
+    return CoreResult(
+      name = nameAllocator.newName("result"),
+      type = type,
+      encoder = encoder,
+      parameter = when {
+        encoder.coreTypes.size > 1 -> {
+          ParameterSpec(
+            nameAllocator.newName("resultParameter"),
+            CoreType.Pointer.kotlinCoreType,
+          )
+        }
+
+        else -> null
+      },
+    )
+  }
+}

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/GuestFunctionFactory.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/GuestFunctionFactory.kt
@@ -32,16 +32,17 @@ internal class GuestFunctionFactory(
     }
   }
 
-  private val coreParameterFactory = CoreParameter.Factory(
+  private val coreValueFactory = CoreValueFactory(
     encoderFactory = encoderFactory,
     nameAllocator = nameAllocator,
   )
 
   private val coreReceiver: CoreParameter? = when {
-    receiver is Receiver.Id -> coreParameterFactory(receiver.name, receiver.type)
+    receiver is Receiver.Id -> coreValueFactory.parameter(receiver.name, receiver.type)
     else -> null
   }
-  private val coreParameters = value.parameters.map { coreParameterFactory(it.name, it.type) }
+  private val coreParameters = value.parameters.map { coreValueFactory.parameter(it.name, it.type) }
+  private val coreResult = value.returnType?.let { coreValueFactory.result(it) }
 
   private val code = CodeBlock.Builder()
 
@@ -70,32 +71,48 @@ internal class GuestFunctionFactory(
           )
         }
 
-        val result = nameAllocator.newName("result")
-        val returnType = value.returnType
-        if (returnType != null) {
-          code.add("val %N = ", result)
+        if (coreResult != null) {
+          when {
+            coreResult.parameter != null -> {
+              encodeBuilder.allocate(coreResult, coreResult.parameter.name)
+              loweredParameters += with(encodeBuilder) {
+                platform.lowerAddress(CodeBlock.of("%N", coreResult.parameter.name))
+              }
+            }
+
+            else -> {
+              code.add("val %N = ", coreResult.name)
+            }
+          }
         }
-        code.add("%N(⇥\n", value.functionName.importFunctionName)
+        code.add("%N(⇥", value.functionName.importFunctionName)
+        if (loweredParameters.isNotEmpty()) {
+          code.add("\n")
+        }
         for (output in loweredParameters) {
           code.add("%L,\n", output)
         }
         code.add("⇤)\n")
 
-        if (returnType != null) {
-          returns(returnType.kotlinApi)
-          val encoder = encoderFactory.get(typeName = returnType)
-          val coreReturnValues = when (encoder.coreTypes.size) {
-            1 -> listOf(CodeBlock.of("%N", result))
-            else -> encodeBuilder.unflattenResult(CodeBlock.of("%N", result), encoder)
+        if (coreResult != null) {
+          returns(coreResult.type.kotlinApi)
+          val coreReturnValues = when {
+            coreResult.parameter != null -> {
+              encodeBuilder.loadResultFromMemory(coreResult.parameter.name, coreResult)
+            }
+
+            else -> {
+              listOf(CodeBlock.of("%N", coreResult.name))
+            }
           }
           val liftedReturnValue = encodeBuilder.lift(
             values = coreReturnValues,
-            encoder = encoder,
+            encoder = coreResult.encoder,
           )
           code.add("return %L", liftedReturnValue)
           code.add(
-            "\n⇥.also{ %M() }⇤",
-            Symbols.KotlinWasm.FreeAllComponentModelReallocAllocatedMemory
+            "\n⇥.also { %M() }⇤\n",
+            Symbols.KotlinWasm.FreeAllComponentModelReallocAllocatedMemory,
           )
         }
       }
@@ -117,14 +134,12 @@ internal class GuestFunctionFactory(
         for (coreParameter in coreParameters) {
           addParameters(coreParameter.specs)
         }
+        if (coreResult?.parameter != null) {
+          addParameter(coreResult.parameter)
+        }
 
-        val returnType = value.returnType
-        if (returnType != null) {
-          val encoder = encoderFactory.get(returnType)
-          when (encoder.coreTypes.size) {
-            1 -> returns(encoder.coreTypes.single().kotlinCoreType)
-            else -> returns(CoreType.Pointer.kotlinCoreType)
-          }
+        if (coreResult != null && coreResult.parameter == null) {
+          returns(coreResult.encoder.coreTypes.single().kotlinCoreType)
         }
       }
       .build()
@@ -143,7 +158,7 @@ internal class GuestFunctionFactory(
             addParameters(coreReceiver!!.specs)
             encodeBuilder.lift(
               values = coreReceiver.names.map { CodeBlock.of("%N", it) },
-              encoder = coreReceiver.encoder
+              encoder = coreReceiver.encoder,
             )
           }
 
@@ -159,10 +174,8 @@ internal class GuestFunctionFactory(
           )
         }
 
-        val result = nameAllocator.newName("result")
-        val returnType = value.returnType
-        if (returnType != null) {
-          code.add("val %N = ", result)
+        if (coreResult != null) {
+          code.add("val %N = ", coreResult.name)
         }
         code.add("%L.%N(⇥\n", liftedReceiver, value.kotlinName)
         for ((index, parameter) in value.parameters.withIndex()) {
@@ -170,21 +183,20 @@ internal class GuestFunctionFactory(
         }
         code.add("⇤)\n")
 
-        if (returnType != null) {
-          val encoder = encoderFactory.get(typeName = returnType)
+        if (coreResult != null) {
           val loweredReturnValues = encodeBuilder.lower(
-            value = CodeBlock.of("%N", result),
-            encoder = encoder,
+            value = CodeBlock.of("%N", coreResult.name),
+            encoder = coreResult.encoder,
           )
-          val flattenedReturnValue = when (encoder.coreTypes.size) {
+          val flattenedReturnValue = when (coreResult.encoder.coreTypes.size) {
             1 -> {
-              returns(encoder.coreTypes.single().kotlinCoreType)
+              returns(coreResult.encoder.coreTypes.single().kotlinCoreType)
               loweredReturnValues.single()
             }
 
             else -> {
               returns(CoreType.Pointer.kotlinCoreType)
-              encodeBuilder.flattenResult(loweredReturnValues, encoder)
+              encodeBuilder.flattenResult(loweredReturnValues, coreResult)
             }
           }
           code.add("return %L\n", flattenedReturnValue)

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/HostFunctionFactory.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/HostFunctionFactory.kt
@@ -16,7 +16,7 @@ import dev.wasmo.brevity.kotlin.generator.HostGenerator.Receiver
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class HostFunctionFactory(
-  private val encoderFactory: EncoderFactory,
+  encoderFactory: EncoderFactory,
   private val value: IrFunction,
   private val bridge: CodeBlock,
 ) {
@@ -29,11 +29,12 @@ internal class HostFunctionFactory(
     }
   }
 
-  private val coreParameterFactory = CoreParameter.Factory(
+  private val coreValueFactory = CoreValueFactory(
     encoderFactory = encoderFactory,
     nameAllocator = nameAllocator,
   )
-  private val coreParameters = value.parameters.map { coreParameterFactory(it.name, it.type) }
+  private val coreParameters = value.parameters.map { coreValueFactory.parameter(it.name, it.type) }
+  private val coreResult = value.returnType?.let { coreValueFactory.result(it) }
 
   private val code = CodeBlock.Builder()
 
@@ -64,10 +65,8 @@ internal class HostFunctionFactory(
           }
         }
 
-        val resultLongArray = nameAllocator.newName("result")
-        val returnType = value.returnType
-        if (returnType != null) {
-          code.add("val %N = ", resultLongArray)
+        if (coreResult != null) {
+          code.add("val %N = ", coreResult.name)
         }
         code.add("%N.apply(⇥\n", value.kotlinName)
         for (longParameter in longParameters) {
@@ -75,23 +74,22 @@ internal class HostFunctionFactory(
         }
         code.add("⇤)\n")
 
-        if (returnType != null) {
-          returns(returnType.kotlinApi)
-          val encoder = encoderFactory.get(typeName = returnType)
-          val coreReturnValues = when (encoder.coreTypes.size) {
+        if (coreResult != null) {
+          returns(coreResult.type.kotlinApi)
+          val coreReturnValues = when (coreResult.encoder.coreTypes.size) {
             1 -> {
-              val result = longToCoreType(resultLongArray, 0, encoder.coreTypes.single())
+              val result = longToCoreType(coreResult.name, 0, coreResult.encoder.coreTypes.single())
               listOf(result)
             }
 
             else -> {
-              val result = longToCoreType(resultLongArray, 0, CoreType.Pointer)
-              encodeBuilder.unflattenResult(result, encoder)
+              val result = longToCoreType(coreResult.name, 0, CoreType.Pointer)
+              encodeBuilder.unflattenResult(result, coreResult)
             }
           }
           val liftedReturnValue = encodeBuilder.lift(
             values = coreReturnValues,
-            encoder = encoder,
+            encoder = coreResult.encoder,
           )
           code.add("return %L", liftedReturnValue)
         }
@@ -116,6 +114,9 @@ internal class HostFunctionFactory(
       for (coreParameter in coreParameters) {
         addAll(coreParameter.encoder.coreTypes)
       }
+      if (coreResult?.parameter != null) {
+        add(CoreType.I32)
+      }
     }
 
     var argIndex = 0
@@ -133,42 +134,51 @@ internal class HostFunctionFactory(
       )
     }
 
-    val returnType = value.returnType
-    val result = nameAllocator.newName("result")
     val self = nameAllocator.newName("self")
     code.addStatement("val %N = %L", self, receiverValue)
-    if (returnType != null) {
-      code.add("val %N = ", result)
+    if (coreResult != null) {
+      code.add("val %N = ", coreResult.name)
     }
-    code.add("%N.%N(⇥\n", self, value.kotlinName)
+    code.add("%N.%N(⇥", self, value.kotlinName)
+    if (value.parameters.isNotEmpty()) {
+      code.add("\n")
+    }
     for ((index, parameter) in value.parameters.withIndex()) {
       code.add("%N = %L,\n", nameAllocator[parameter.name], liftedParameterValues[index])
     }
     code.add("⇤)\n")
 
     val returnValType: CoreType?
-    if (returnType != null) {
-      val encoder = encoderFactory.get(returnType)
+    if (coreResult != null) {
       val loweredReturnValues = encodeBuilder.lower(
-        value = CodeBlock.of("%N", result),
-        encoder = encoder,
+        value = CodeBlock.of("%N", coreResult.name),
+        encoder = coreResult.encoder,
       )
-      val flattenedReturnValue = when (encoder.coreTypes.size) {
-        1 -> {
-          returnValType = encoder.coreTypes.single()
-          loweredReturnValues.single()
+      when {
+        coreResult.parameter != null -> {
+          code.addStatement(
+            "val %N = %L",
+            coreResult.parameter.name,
+            longToCoreType("args", argIndex++, CoreType.Pointer),
+          )
+          encodeBuilder.storeResultInMemory(
+            returnValues = loweredReturnValues,
+            coreResult = coreResult,
+            address = coreResult.parameter.name,
+          )
+          returnValType = null
+          code.add("return@%T longArrayOf()", Symbols.ChicoryRuntime.WasmFunctionHandle)
         }
 
         else -> {
-          returnValType = CoreType.Pointer
-          encodeBuilder.flattenResult(loweredReturnValues, encoder)
+          returnValType = coreResult.encoder.coreTypes.single()
+          code.add(
+            "return@%T longArrayOf(%L)",
+            Symbols.ChicoryRuntime.WasmFunctionHandle,
+            coreTypeToLong(loweredReturnValues.single(), returnValType),
+          )
         }
       }
-      code.add(
-        "return@%T longArrayOf(%L)",
-        Symbols.ChicoryRuntime.WasmFunctionHandle,
-        coreTypeToLong(flattenedReturnValue, returnValType),
-      )
     } else {
       returnValType = null
       code.add("return@%T longArrayOf()", Symbols.ChicoryRuntime.WasmFunctionHandle)

--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/RealEncodeBuilder.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/RealEncodeBuilder.kt
@@ -88,16 +88,31 @@ class RealEncodeBuilder(
   }
 
   /** When there's multiple core values to return, write them to memory and return a pointer. */
-  fun flattenResult(returnValues: List<CodeBlock>, encoder: Encoder): CodeBlock {
-    val coreTypes = encoder.coreTypes
+  fun flattenResult(returnValues: List<CodeBlock>, coreResult: CoreResult): CodeBlock {
+    val address = nameAllocator.newName("resultAddress")
+    allocate(coreResult, address)
+    storeResultInMemory(returnValues, coreResult, address)
+    return platform.lowerAddress(CodeBlock.of("%N", address))
+  }
 
-    val byteCount = coreTypes.sumOf { coreType ->
+  /** Allocate space for the encoded value at [address]. */
+  fun allocate(coreResult: CoreResult, address: String) {
+    val byteCount = coreResult.encoder.coreTypes.sumOf { coreType ->
       coreType.byteCount
     }
 
-    val address = nameAllocator.newName("resultAddress")
-    var offset = 0
     code.addStatement("val %N = %L", address, allocate("%L", byteCount))
+  }
+
+  /** Write all of [returnValues] to [address]. */
+  fun storeResultInMemory(
+    returnValues: List<CodeBlock>,
+    coreResult: CoreResult,
+    address: String,
+  ) {
+    val coreTypes = coreResult.encoder.coreTypes
+
+    var offset = 0
     for ((index, value) in returnValues.withIndex()) {
       val coreType = coreTypes[index]
       platform.store(
@@ -108,17 +123,20 @@ class RealEncodeBuilder(
       )
       offset += coreType.byteCount
     }
-
-    return platform.lowerAddress(CodeBlock.of("%N", address))
   }
 
   /** When an address is returned, unpack the core values from memory. */
-  fun unflattenResult(returnValue: CodeBlock, encoder: Encoder): List<CodeBlock> {
-    val coreTypes = encoder.coreTypes
-    val nameHints = encoder.nameHints
-
+  fun unflattenResult(returnValue: CodeBlock, coreResult: CoreResult): List<CodeBlock> {
     val address = nameAllocator.newName("resultAddress")
     code.addStatement("val %N = %L", address, platform.liftAddress(returnValue))
+
+    return loadResultFromMemory(address, coreResult)
+  }
+
+  /** Unpack core values from memory. */
+  fun loadResultFromMemory(address: String, coreResult: CoreResult): List<CodeBlock> {
+    val coreTypes = coreResult.encoder.coreTypes
+    val nameHints = coreResult.encoder.nameHints
 
     var offset = 0
     val result = mutableListOf<CodeBlock>()
@@ -138,7 +156,7 @@ class RealEncodeBuilder(
         platform.load(
           baseAddress = CodeBlock.of("%N", address),
           offset = offset,
-          type = CoreType.I32
+          type = CoreType.I32,
         ),
       )
       offset += coreType.byteCount

--- a/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/KotlinGeneratorTest.kt
+++ b/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/KotlinGeneratorTest.kt
@@ -368,8 +368,7 @@ class KotlinGeneratorTest {
       |        ),
       |        WasmFunctionHandle { instance, args ->
       |          val self = host
-      |          val result = self.args(
-      |          )
+      |          val result = self.args()
       |          return@WasmFunctionHandle longArrayOf((result as Int).toLong())
       |        },
       |      )
@@ -717,8 +716,7 @@ class KotlinGeneratorTest {
       |        ),
       |        WasmFunctionHandle { instance, args ->
       |          val self = host.monotonicClock
-      |          val result = self.now(
-      |          )
+      |          val result = self.now()
       |          return@WasmFunctionHandle longArrayOf(result)
       |        },
       |      )
@@ -938,7 +936,7 @@ class KotlinGeneratorTest {
       |  module = "namespace:package-name/test",
       |  name = "[method]person.get-name",
       |)
-      |private external fun test_person_getName_import(self: Int): Int
+      |private external fun test_person_getName_import(self: Int, resultParameter: Int)
       |
       |@WasmImport(
       |  module = "namespace:package-name/test",
@@ -948,20 +946,24 @@ class KotlinGeneratorTest {
       |  self: Int,
       |  namePointer: Int,
       |  nameByteCount: Int,
-      |): Int
+      |  resultParameter: Int,
+      |)
       |
       |internal class PersonHandle(
       |  private val id: Int,
       |) : Test.Person {
       |  override fun getName(): String {
-      |    val result = test_person_getName_import(
-      |      this.id,
-      |    )
-      |    val resultAddress = Pointer(result.toUInt())
-      |    val resultPointer = resultAddress.loadInt()
-      |    val resultByteCount = (resultAddress + 4).loadInt()
-      |    return Pointer(resultPointer.toUInt()).loadString(resultByteCount)
-      |      .also{ freeAllComponentModelReallocAllocatedMemory() }
+      |    withScopedMemoryAllocator { memoryAllocator ->
+      |      val resultParameter = memoryAllocator.allocate(8)
+      |      test_person_getName_import(
+      |        this.id,
+      |        resultParameter.address.toInt(),
+      |      )
+      |      val resultPointer = resultParameter.loadInt()
+      |      val resultByteCount = (resultParameter + 4).loadInt()
+      |      return Pointer(resultPointer.toUInt()).loadString(resultByteCount)
+      |        .also { freeAllComponentModelReallocAllocatedMemory() }
+      |    }
       |  }
       |
       |  override fun replaceName(name: String): String {
@@ -969,16 +971,18 @@ class KotlinGeneratorTest {
       |      val byteArray = name.encodeToByteArray()
       |      val address = memoryAllocator.allocate(byteArray.size)
       |      address.storeByteArray(byteArray)
-      |      val result = test_person_replaceName_import(
+      |      val resultParameter = memoryAllocator.allocate(8)
+      |      test_person_replaceName_import(
       |        this.id,
       |        address.address.toInt(),
       |        byteArray.size,
+      |        resultParameter.address.toInt(),
       |      )
-      |      val resultAddress = Pointer(result.toUInt())
-      |      val resultPointer = resultAddress.loadInt()
-      |      val resultByteCount = (resultAddress + 4).loadInt()
+      |      val resultPointer = resultParameter.loadInt()
+      |      val resultByteCount = (resultParameter + 4).loadInt()
       |      return Pointer(resultPointer.toUInt()).loadString(resultByteCount)
-      |        .also{ freeAllComponentModelReallocAllocatedMemory() }}
+      |        .also { freeAllComponentModelReallocAllocatedMemory() }
+      |    }
       |  }
       |}
       |
@@ -1027,20 +1031,19 @@ class KotlinGeneratorTest {
       |        "namespace:package-name/test",
       |        "[method]person.get-name",
       |        FunctionType.of(
-      |          listOf(ValType.I32),
-      |          listOf(ValType.I32),
+      |          listOf(ValType.I32, ValType.I32),
+      |          listOf(),
       |        ),
       |        WasmFunctionHandle { instance, args ->
       |          val self = bridge.`get`<Test.Person>(args[0].toInt())
-      |          val result = self.getName(
-      |          )
+      |          val result = self.getName()
       |          val byteArray = result.encodeToByteArray()
       |          val pointer = bridge.allocate(byteArray.size)
       |          bridge.memory.write(pointer, byteArray)
-      |          val resultAddress = bridge.allocate(8)
-      |          bridge.memory.writeI32(resultAddress, pointer)
-      |          bridge.memory.writeI32(resultAddress + 4, byteArray.size)
-      |          return@WasmFunctionHandle longArrayOf(resultAddress.toLong())
+      |          val resultParameter = args[1].toInt()
+      |          bridge.memory.writeI32(resultParameter, pointer)
+      |          bridge.memory.writeI32(resultParameter + 4, byteArray.size)
+      |          return@WasmFunctionHandle longArrayOf()
       |        },
       |      )
       |    )
@@ -1049,8 +1052,8 @@ class KotlinGeneratorTest {
       |        "namespace:package-name/test",
       |        "[method]person.replace-name",
       |        FunctionType.of(
-      |          listOf(ValType.I32, ValType.I32, ValType.I32),
-      |          listOf(ValType.I32),
+      |          listOf(ValType.I32, ValType.I32, ValType.I32, ValType.I32),
+      |          listOf(),
       |        ),
       |        WasmFunctionHandle { instance, args ->
       |          val self = bridge.`get`<Test.Person>(args[0].toInt())
@@ -1060,10 +1063,10 @@ class KotlinGeneratorTest {
       |          val byteArray = result.encodeToByteArray()
       |          val pointer = bridge.allocate(byteArray.size)
       |          bridge.memory.write(pointer, byteArray)
-      |          val resultAddress = bridge.allocate(8)
-      |          bridge.memory.writeI32(resultAddress, pointer)
-      |          bridge.memory.writeI32(resultAddress + 4, byteArray.size)
-      |          return@WasmFunctionHandle longArrayOf(resultAddress.toLong())
+      |          val resultParameter = args[3].toInt()
+      |          bridge.memory.writeI32(resultParameter, pointer)
+      |          bridge.memory.writeI32(resultParameter + 4, byteArray.size)
+      |          return@WasmFunctionHandle longArrayOf()
       |        },
       |      )
       |    )


### PR DESCRIPTION
This is an optimization in the ABI that allows the guest to allocate a place for the result to land. The exact rules on when this optimization aren't completely clear, but this seems to interop well enough in the example I tried.