### PR TITLE
Clean up PackageRef and provide granular siting info

### DIFF
--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/validation/validations.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/io/validation/validations.kt
@@ -19,41 +19,48 @@ import okio.Path
 fun validateUniquePackageNames(
   toplevelPackages: List<IoToplevelWitPackage>,
 ): Map<PackageName, IoWitPackage> {
-  val packageRefs = mutableMapOf<PackageName, MutableList<PackageRef>>()
+  val witPackageMap = mutableMapOf<PackageName, MutableList<IoWitPackage>>()
 
-  fun addPackage(packageName: PackageName, packageRef: PackageRef) {
-    packageRefs.getOrPut(packageName) { mutableListOf() }.add(packageRef)
+  fun addPackage(packageName: PackageName, witPackage: IoWitPackage) {
+    witPackageMap.getOrPut(packageName) { mutableListOf() }.add(witPackage)
   }
   for (topLevelPackage in toplevelPackages) {
-    addPackage(topLevelPackage.packageName, PackageRef.Directory(topLevelPackage))
+    addPackage(topLevelPackage.packageName, topLevelPackage)
 
     for (file in topLevelPackage.files) {
       for (inlinePackage in file.items.filterIsInstance<IoInlinePackage>()) {
         addPackage(
           inlinePackage.packageName,
-          PackageRef.Inline(file, inlinePackage),
+          inlinePackage,
         )
       }
     }
   }
-  val collisions = mutableMapOf<PackageName, List<PackageRef>>()
+  val collisions = mutableMapOf<PackageName, List<IoWitPackage>>()
   val output = mutableMapOf<PackageName, IoWitPackage>()
 
-  for ((packageName, packageRefs) in packageRefs) {
-    when (packageRefs.size) {
+  for ((packageName, witPackages) in witPackageMap) {
+    when (witPackages.size) {
       0 -> error("Invariant violated: package name exists without reference")
-      1 -> output[packageName] = packageRefs.single().`package`
+      1 -> output[packageName] = witPackages.single()
       else -> {
-        output[packageName] = packageRefs.first().`package`
-        collisions[packageName] = packageRefs
+        output[packageName] = witPackages.first()
+        collisions[packageName] = witPackages
       }
     }
   }
 
-  val collisionExceptions = collisions.map { (packageName, packageRefs) ->
+  val collisionExceptions = collisions.map { (packageName, packages) ->
     Issue(
       "Duplicate definitions of $packageName",
-      packageRefs.map { packageRef -> packageRef.location }.toList(),
+      packages.flatMap { witPackage ->
+        when (witPackage) {
+          is IoInlinePackage -> listOf(witPackage.location)
+          is IoToplevelWitPackage -> witPackage.files.mapNotNull { witFile ->
+            witFile.location.takeIf { witFile.packageName != null }
+          }
+        }
+      }.toList(),
     )
   }.map(::WitException)
 
@@ -64,27 +71,6 @@ fun validateUniquePackageNames(
   }
 
   return output
-}
-
-sealed interface PackageRef {
-  val `package`: IoWitPackage
-  val location: Location
-
-  data class Directory(
-    override val `package`: IoToplevelWitPackage,
-  ) : PackageRef {
-    override val location = `package`.files.firstNotNullOf { file ->
-      file.location.takeIf { file.packageName != null }
-    }
-  }
-
-  data class Inline(
-    val file: IoWitFile,
-    override val `package`: IoInlinePackage,
-  ) : PackageRef {
-    override val location: Location
-      get() = `package`.location
-  }
 }
 
 fun validateUniqueServiceNames(toplevelPackages: List<IoToplevelWitPackage>): Map<ServiceName, IoService> {
@@ -103,6 +89,7 @@ fun validateUniqueServiceNames(toplevelPackages: List<IoToplevelWitPackage>): Ma
             ServiceName(pkg.packageName, item.name),
             item,
           )
+
           is IoTopLevelUse -> {}
         }
       }
@@ -138,7 +125,7 @@ fun validateUniqueServiceNames(toplevelPackages: List<IoToplevelWitPackage>): Ma
 
 private fun processInlinePackage(
   pkg: IoInlinePackage,
-  addService: (ServiceName, IoService) -> Unit
+  addService: (ServiceName, IoService) -> Unit,
 ) {
   for (decl in pkg.declarations) {
     when (decl) {
@@ -147,6 +134,7 @@ private fun processInlinePackage(
         ServiceName(pkg.packageName, decl.name),
         decl,
       )
+
       is IoTopLevelUse -> {}
     }
   }

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidateUniquePackageNamesTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/validation/ValidateUniquePackageNamesTest.kt
@@ -22,10 +22,10 @@ class ValidateUniquePackageNamesTest {
       packageName = "wasi:cli".toPackageName(),
       files = listOf(
         IoWitFile(
-location = cliLocation,
+          location = cliLocation,
           packageName = "wasi:cli".toPackageName(),
-        )
-      )
+        ),
+      ),
     )
     val otherLocation = Location("other/other.wit")
     val inlinePackage = IoInlinePackage(
@@ -37,13 +37,13 @@ location = cliLocation,
       packageName = "wasi:other".toPackageName(),
       files = listOf(
         IoWitFile(
-location = otherLocation,
+          location = otherLocation,
           packageName = "wasi:other".toPackageName(),
           items = listOf(
-            inlinePackage
-          )
-        )
-      )
+            inlinePackage,
+          ),
+        ),
+      ),
     )
     val packages = listOf(cliPackage, otherPackage)
 
@@ -59,14 +59,19 @@ location = otherLocation,
   @Test
   fun throwsOnCollision() {
     val cliLocation = Location("cli.wit")
+    val cliExtraLocation = Location("cli-extra.wit")
     val cliPackage = IoToplevelWitPackage(
       packageName = "wasi:cli".toPackageName(),
       files = listOf(
         IoWitFile(
-location = cliLocation,
+          location = cliLocation,
           packageName = "wasi:cli".toPackageName(),
-        )
-      )
+        ),
+        IoWitFile(
+          location = cliExtraLocation,
+          packageName = "wasi:cli".toPackageName(),
+        ),
+      ),
     )
     val otherLocation = Location("other/other.wit")
     val inlinePackage = IoInlinePackage(
@@ -78,26 +83,30 @@ location = cliLocation,
       packageName = "wasi:other".toPackageName(),
       files = listOf(
         IoWitFile(
-location = otherLocation,
+          location = otherLocation,
           packageName = "wasi:other".toPackageName(),
           items = listOf(
-            inlinePackage
-          )
-        )
-      )
+            inlinePackage,
+          ),
+        ),
+      ),
     )
     val exception = assertFailsWith<WitException> {
       validateUniquePackageNames(listOf(cliPackage, otherPackage))
     }
 
-    assertThat(exception.message).isEqualTo("""
+    assertThat(exception.message).isEqualTo(
+      """
       |Duplicate definitions of wasi:cli
       |${"\t"}at cli.wit
-      |${"\t"}at other/other.wit:1:2""".trimMargin())
+      |${"\t"}at cli-extra.wit
+      |${"\t"}at other/other.wit:1:2""".trimMargin(),
+    )
 
     assertThat(exception.issue.locations).containsExactlyInAnyOrder(
       otherLocation.at(1, 2),
       cliLocation,
+      cliExtraLocation,
     )
   }
 
@@ -108,10 +117,10 @@ location = otherLocation,
       packageName = "wasi:cli".toPackageName(),
       files = listOf(
         IoWitFile(
-location = cliLocation,
+          location = cliLocation,
           packageName = "wasi:cli".toPackageName(),
-        )
-      )
+        ),
+      ),
     )
     val otherLocation = Location("other/other.wit")
     val inlinePackage = IoInlinePackage(
@@ -128,20 +137,21 @@ location = cliLocation,
       packageName = "wasi:other".toPackageName(),
       files = listOf(
         IoWitFile(
-location = otherLocation,
+          location = otherLocation,
           packageName = "wasi:other".toPackageName(),
           items = listOf(
             inlinePackage,
             anotherInlinePackage,
-          )
-        )
-      )
+          ),
+        ),
+      ),
     )
     val exception = assertFailsWith<WitCompoundException> {
       validateUniquePackageNames(listOf(cliPackage, otherPackage))
     }
 
-    assertThat(exception.message).isEqualTo("""
+    assertThat(exception.message).isEqualTo(
+      """
       |Multiple issues found:
       |Duplicate definitions of wasi:cli
       |${"\t"}at cli.wit
@@ -149,7 +159,8 @@ location = otherLocation,
       |Duplicate definitions of wasi:other
       |${"\t"}at other/other.wit
       |${"\t"}at other/other.wit:1:2
-      |""".trimMargin())
+      |""".trimMargin(),
+    )
 
     val (firstException, secondException) = exception.witExceptions.filterIsInstance<WitException>()
 


### PR DESCRIPTION
We have sufficient information in the Io decls now to get rid of PackageRef, but that also puts a finger on an issue with the old implementation: if your toplevel package defines the conflicting package name five times, we boorishly only point you to the folder! Kind of? Anyway, fixing it