### PR TITLE
Make upperCamelCase and lowerCamelCase fail for malformed identifiers

### DIFF
--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CamelCase.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CamelCase.kt
@@ -1,6 +1,8 @@
 package dev.wasmo.brevity.kotlin.generator
 
 import dev.wasmo.brevity.Identifier
+import dev.wasmo.brevity.MalformedIdentifier
+import dev.wasmo.brevity.WitIdentifier
 
 /**
  * Returns the `kabob-case` [Identifier.name] as `lowerCamelCase`.
@@ -14,12 +16,13 @@ val Identifier.lowerCamelCase: String
 val Identifier.upperCamelCase: String
   get() = toCamelCase(true)
 
-private fun Identifier.toCamelCase(upperCamel: Boolean): String {
+private fun Identifier.toCamelCase(upperCamel: Boolean): String = when (this) {
+  is MalformedIdentifier -> error("Generating code for malformed identifier ${this.name}")
+  is WitIdentifier ->
   return buildString {
     var uppercase = upperCamel
     for (char in name) {
       when (char) {
-        '%' -> continue
         '-' -> {
           uppercase = true
           continue

--- a/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/CamelCaseTest.kt
+++ b/brevity-kotlin-generator/src/jvmTest/kotlin/dev/wasmo/brevity/kotlin/generator/CamelCaseTest.kt
@@ -4,16 +4,16 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import dev.wasmo.brevity.Identifier
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class CamelCaseTest {
   @Test
   fun `upper camel case`() {
-    assertThat(Identifier("").upperCamelCase)
-      .isEqualTo("")
-    assertThat(Identifier("-").upperCamelCase)
-      .isEqualTo("")
-    assertThat(Identifier("-w--").upperCamelCase)
-      .isEqualTo("W")
+    assertFailsWith<IllegalStateException> { Identifier("").upperCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("-").upperCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("-w--").upperCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("WA%LL-C%LO%CK").upperCamelCase }
+
     assertThat(Identifier("wall-clock").upperCamelCase)
       .isEqualTo("WallClock")
     assertThat(Identifier("WALL-clock").upperCamelCase)
@@ -22,22 +22,18 @@ class CamelCaseTest {
       .isEqualTo("WallClock")
     assertThat(Identifier("WALL-CLOCK").upperCamelCase)
       .isEqualTo("WallClock")
-    assertThat(Identifier("WA%LL-C%LO%CK").upperCamelCase)
-      .isEqualTo("WallClock")
     assertThat(Identifier("w123-4567clock").upperCamelCase)
       .isEqualTo("W1234567clock")
   }
 
   @Test
   fun `lower camel case`() {
-    assertThat(Identifier("").lowerCamelCase)
-      .isEqualTo("")
-    assertThat(Identifier("-").lowerCamelCase)
-      .isEqualTo("")
-    assertThat(Identifier("-w--").lowerCamelCase)
-      .isEqualTo("W")
-    assertThat(Identifier("w---").lowerCamelCase)
-      .isEqualTo("w")
+    assertFailsWith<IllegalStateException> { Identifier("").lowerCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("-").lowerCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("-w--").lowerCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("w---").lowerCamelCase }
+    assertFailsWith<IllegalStateException> { Identifier("WA%LL-C%LO%CK").lowerCamelCase }
+
     assertThat(Identifier("wall-clock").lowerCamelCase)
       .isEqualTo("wallClock")
     assertThat(Identifier("WALL-clock").lowerCamelCase)
@@ -45,8 +41,6 @@ class CamelCaseTest {
     assertThat(Identifier("wall-CLOCK").lowerCamelCase)
       .isEqualTo("wallClock")
     assertThat(Identifier("WALL-CLOCK").lowerCamelCase)
-      .isEqualTo("wallClock")
-    assertThat(Identifier("WA%LL-C%LO%CK").lowerCamelCase)
       .isEqualTo("wallClock")
     assertThat(Identifier("w123-4567clock").lowerCamelCase)
       .isEqualTo("w1234567clock")


### PR DESCRIPTION
I'm thinking we shouldn't even be trying to emit source if these are malformed? 