### PR TITLE
Hide MalformedIdentifier

### DIFF
--- a/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CamelCase.kt
+++ b/brevity-kotlin-generator/src/jvmMain/kotlin/dev/wasmo/brevity/kotlin/generator/CamelCase.kt
@@ -1,7 +1,6 @@
 package dev.wasmo.brevity.kotlin.generator
 
 import dev.wasmo.brevity.Identifier
-import dev.wasmo.brevity.MalformedIdentifier
 import dev.wasmo.brevity.WitIdentifier
 
 /**
@@ -16,9 +15,9 @@ val Identifier.lowerCamelCase: String
 val Identifier.upperCamelCase: String
   get() = toCamelCase(true)
 
-private fun Identifier.toCamelCase(upperCamel: Boolean): String = when (this) {
-  is MalformedIdentifier -> error("Generating code for malformed identifier ${this.name}")
-  is WitIdentifier ->
+private fun Identifier.toCamelCase(upperCamel: Boolean): String = if (this !is WitIdentifier) {
+  error("Generating code for malformed identifier ${this.name}")
+} else {
   return buildString {
     var uppercase = upperCamel
     for (char in name) {

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/Identifier.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/Identifier.kt
@@ -1,15 +1,22 @@
 package dev.wasmo.brevity
 
-import dev.wasmo.brevity.io.isDigit
-import dev.wasmo.brevity.io.isLowerCase
-import dev.wasmo.brevity.io.isUpperCase
-
 sealed interface Identifier {
   val name: String
 }
 
+/**
+ * Private implementation used exclusively to represent malformed identifiers.
+ *
+ * Would prefer to do something like this:
+ * value class WitIdentifier : IoIdentifier
+ * value class IoIdentifier
+ *
+ * ...but value classes are required to be final.
+ *
+ * Value classes are pretty restrictive, as it turns out!
+ */
 @JvmInline
-value class MalformedIdentifier internal constructor(
+private value class MalformedIdentifier(
   override val name: String,
 ): Identifier
 
@@ -28,6 +35,10 @@ value class WitIdentifier internal constructor(
 
 private val identifierRegex = Regex("^%?([a-z][a-z0-9]*|[A-Z][A-Z0-9]*)(-[a-z0-9]+|-[A-Z0-9]+)*$")
 
+/**
+ * Parse [name] into an instance of [Identifier]. Valid WIT identifiers will be instances of
+ * [WitIdentifier].
+ */
 fun Identifier(name: String): Identifier {
   return if (identifierRegex.matches(name)) {
     WitIdentifier(name)

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/IdentifierTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/IdentifierTest.kt
@@ -2,6 +2,7 @@ package dev.wasmo.brevity
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotInstanceOf
 import org.junit.Test
 
 class IdentifierTest {
@@ -78,7 +79,7 @@ class IdentifierTest {
   }
 
   fun String.assertIsMalformed() {
-    assertThat(Identifier(this)).isEqualTo(MalformedIdentifier(this))
+    assertThat(Identifier(this)).isNotInstanceOf<WitIdentifier>()
   }
 
   fun String.assertIsWellFormed() {


### PR DESCRIPTION
I think that doing this means that we lose the benefit of a value class — references to `Identifier` will be boxed, I suppose? 

The other way to do this, if we're choosing to restrict IR to well-formed identifiers, would be to just not do this at all on first parse and instead only do it on lower to IR. 