### PR TITLE
Configure the exact version of The Kotlin Toolchain

### DIFF
--- a/.buildkite/build.yml
+++ b/.buildkite/build.yml
@@ -5,7 +5,7 @@ steps:
       - "gradle check"
     plugins:
       - docker#v5.13.0:
-          image: wasmo/brevity-ci@sha256:04f5e898051ed3dac03eb4407bce409720e70787dcd7aaef83dc960a911b99f7
+          image: wasmo/brevity-ci@sha256:00a5829f37e64c7c459184ec6312b0d6134bea7ab96ce10c10bc1ee0ac8dcc40
           run: ci-build
           environment:
             - "BUILDKITE_ANALYTICS_TOKEN"

--- a/.buildkite/publish.yml
+++ b/.buildkite/publish.yml
@@ -5,7 +5,7 @@ steps:
       - "gradle publishAndReleaseToMavenCentral"
     plugins:
       - docker#v5.13.0:
-          image: wasmo/brevity-ci@sha256:04f5e898051ed3dac03eb4407bce409720e70787dcd7aaef83dc960a911b99f7
+          image: wasmo/brevity-ci@sha256:00a5829f37e64c7c459184ec6312b0d6134bea7ab96ce10c10bc1ee0ac8dcc40
           run: ci-build
           environment:
             - "ORG_GRADLE_PROJECT_mavenCentralUsername"

--- a/brevity-build/brevity-ci/Dockerfile
+++ b/brevity-build/brevity-ci/Dockerfile
@@ -166,13 +166,17 @@ RUN --mount=type=cache,target=/downloads,rw \
 
 # Kotlin toolchain.
 # We run '--version' because it downloads its dependencies on the first run.
-ENV KOTLIN_CLI_NO_WELCOME_BANNER="1"
+ENV KOTLIN_CLI_VERSION="0.12.0"
+ENV KOTLIN_CLI_HOME="/root/.local/bin"
 ENV KOTLIN_CLI_JAVA_HOME="$JAVA_HOME"
-ENV HOME="/root"
-ENV PATH="/root/.local/bin:$PATH"
+ENV KOTLIN_CLI_NO_WELCOME_BANNER="1"
+ENV PATH="$KOTLIN_CLI_HOME:$PATH"
 RUN echo "Installing Kotlin toolchain" \
     && set -o errexit -o nounset \
     && curl -fsSL https://kotl.in/install.sh | sh \
-    && kotlin --version
+    && cd "$KOTLIN_CLI_HOME" \
+    && kotlin update --target-version "$KOTLIN_CLI_VERSION" --create \
+    && kotlin --version \
+    && cd / \
 
 CMD ["gradle"]

--- a/docs/development/kotlin_toolchain.md
+++ b/docs/development/kotlin_toolchain.md
@@ -4,10 +4,16 @@ The Kotlin Toolchain
 This project builds with Gradle, but its test suite also uses [The Kotlin Toolchain] to build
 generated test projects.
 
+We use version 0.12.0.
+
 Install it like this:
 
 ```bash
+$ export KOTLIN_CLI_VERSION="0.12.0"
 $ curl -fsSL https://kotl.in/install.sh | sh
+$ cd ~/.local/bin
+$ kotlin update --target-version "$KOTLIN_CLI_VERSION" --create
+$ kotlin --version
 ```
 
 [The Kotlin Toolchain]: https://kotlin-toolchain.org/latest/


### PR DESCRIPTION
We are currently on the latest, 0.12.0.

With this change it'll be more difficult to accidentally get a different version.