### PR TITLE
Ignore preceding % signs on identifiers

### DIFF
--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/Identifier.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/Identifier.kt
@@ -47,8 +47,8 @@ private val identifierRegex = Regex("^%?([a-z][a-z0-9]*|[A-Z][A-Z0-9]*)(-[a-z0-9
  */
 fun Identifier(name: String): Identifier {
   return if (identifierRegex.matches(name)) {
-    WitIdentifier(name)
+    WitIdentifier(name.removePrefix("%"))
   } else {
-    MalformedIdentifier(name)
+    MalformedIdentifier(name.removePrefix("%"))
   }
 }

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/IdentifierTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/IdentifierTest.kt
@@ -27,8 +27,8 @@ class IdentifierTest {
     "A11-4CR0NYMS".assertIsWellFormed()
     // Sections with different casings are fine, too
     "m1x3d-4CR0NYMS".assertIsWellFormed()
-    // Prefix with % sign as a keyword disambiguator
-    "%abd".assertIsWellFormed()
+    // Prefix with % sign as a keyword disambiguator - % gets dropped
+    assertThat(Identifier("%abd")).isEqualTo(WitIdentifier("abd"))
 
     // No empties
     "".assertIsMalformed()


### PR DESCRIPTION
Well. Value classes are a bit of a hairshirt. We can't override equals+hashCode, which kinda breaks what I was thinking we could do.

So rather than trying to do something fancy, here's something dumb that will definitely work semantically: just ignore `%` as soon as it's parsed. 

If it makes things feel dumb, we can always change our minds later!