### PR TITLE
Fix some build flakiness

### DIFF
--- a/brevity-build/src/main/kotlin/dev/wasmo/brevity/gradle/BrevityBuildPlugin.kt
+++ b/brevity-build/src/main/kotlin/dev/wasmo/brevity/gradle/BrevityBuildPlugin.kt
@@ -8,6 +8,7 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.MavenPublishBasePlugin
 import com.vanniktech.maven.publish.SourcesJar
+import java.io.File
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -22,6 +23,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 @Suppress("unused") // Used reflectively.
 class BrevityBuildPlugin : Plugin<Project> {
   override fun apply(project: Project) {
+    val buildDirectory = project.findProperty("brevity.build.directory")
+    if (buildDirectory != null) {
+      project.layout.buildDirectory.set(File(project.rootDir, "${buildDirectory}/${project.name}"))
+    }
+
     val libs = project.extensions.getByName("libs") as LibrariesForLibs
 
     project.extensions.add(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,9 +67,4 @@ allprojects {
       version = "26.1.0"
     }
   }
-
-  val buildDirectory = project.findProperty("brevity.build.directory")
-  if (buildDirectory != null) {
-    layout.buildDirectory.set(File(rootDir, "${buildDirectory}/${project.name}"))
-  }
 }


### PR DESCRIPTION
Changing the project's buildDirectory needs to be done early in the project setup, otherwise execution can be flaky. My hypothesis is that some tasks capture that directory before its mutated.