### PR TITLE
Fix formatting of type names

### DIFF
--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/IoPackageName.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/IoPackageName.kt
@@ -63,8 +63,8 @@ private data class WitPackageName(
   override val namespaces: List<Identifier>,
   override val names: List<Identifier>,
   override val version: SemVer? = null,
-): PackageName {
-  override fun toString() = toStringImpl()
+) : PackageName {
+  override fun toString() = nameToString(this)
 
   override fun equals(other: Any?): Boolean = equalsImpl(other)
 
@@ -77,7 +77,7 @@ private data class MalformedPackageName(
   override val names: List<IoIdentifier>,
   override val version: SemVer? = null,
 ) : IoPackageName {
-  override fun toString() = toStringImpl()
+  override fun toString() = nameToString(this)
 
   override fun equals(other: Any?): Boolean = equalsImpl(other)
 
@@ -90,18 +90,3 @@ private fun IoPackageName.equalsImpl(other: Any?): Boolean = other is IoPackageN
   namespaces == other.namespaces &&
   names == other.names &&
   version == other.version
-
-private fun IoPackageName.toStringImpl(): String = buildString {
-  for (name in namespaces) {
-    append(name)
-    append(':')
-  }
-  for ((index, name) in names.withIndex()) {
-    if (index > 0) append('/')
-    append(name)
-  }
-  version?.let {
-    append("@")
-    append(it.version)
-  }
-}

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/IoServiceName.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/IoServiceName.kt
@@ -19,7 +19,7 @@ sealed interface IoServiceName : Comparable<IoServiceName> {
 fun ServiceName(
   packageName: PackageName,
   name: Identifier,
-  ): ServiceName = WitServiceName(packageName, name)
+): ServiceName = WitServiceName(packageName, name)
 
 fun ServiceName(
   packageName: IoPackageName,
@@ -47,8 +47,11 @@ sealed interface ServiceName : IoServiceName {
 private data class WitServiceName(
   override val packageName: PackageName,
   override val name: Identifier,
-): ServiceName {
-  override fun toString() = renderString()
+) : ServiceName {
+  override fun toString() = nameToString(
+    packageName = packageName,
+    serviceName = name,
+  )
 
   override fun equals(other: Any?): Boolean {
     return toString() == other.toString()
@@ -66,9 +69,9 @@ private data class WitServiceName(
  * identifiers.
  */
 private data class MalformedServiceName(
-    override val packageName: IoPackageName,
-    override val name: IoIdentifier,
-): IoServiceName {
+  override val packageName: IoPackageName,
+  override val name: IoIdentifier,
+) : IoServiceName {
   override fun equals(other: Any?): Boolean {
     return toString() == other.toString()
   }
@@ -77,21 +80,8 @@ private data class MalformedServiceName(
     return toString().hashCode()
   }
 
-  override fun toString() = renderString()
-}
-
-private fun IoServiceName.renderString(): String = buildString {
-  for (namespace in packageName.namespaces) {
-    append(namespace)
-    append(':')
-  }
-  for (packageName in packageName.names) {
-    append(packageName)
-    append('/')
-  }
-  append(name)
-  if (packageName.version != null) {
-    append('@')
-    append(packageName.version)
-  }
+  override fun toString() = nameToString(
+    packageName = packageName,
+    serviceName = name,
+  )
 }

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/NameToString.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/NameToString.kt
@@ -1,0 +1,39 @@
+package dev.wasmo.brevity
+
+/**
+ * Convert a symbol name to a string.
+ *
+ * This can be used for packages, services, and types. All of these share common syntax.
+ */
+internal fun nameToString(
+  packageName: IoPackageName,
+  serviceName: IoIdentifier? = null,
+  typeName: IoIdentifier? = null,
+): String {
+  require(typeName == null || serviceName != null) {
+    "cannot have a type name without a service name"
+  }
+
+  return buildString {
+    for (namespace in packageName.namespaces) {
+      append(namespace)
+      append(':')
+    }
+    for ((i, name) in packageName.names.withIndex()) {
+      if (i > 0) append('/')
+      append(name)
+    }
+    if (serviceName != null) {
+      append('/')
+      append(serviceName)
+      if (typeName != null) {
+        append('.')
+        append(typeName)
+      }
+    }
+    if (packageName.version != null) {
+      append('@')
+      append(packageName.version)
+    }
+  }
+}

--- a/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/TypeName.kt
+++ b/brevity-wit/src/jvmMain/kotlin/dev/wasmo/brevity/TypeName.kt
@@ -23,7 +23,11 @@ sealed class TypeName {
       val serviceName: ServiceName,
       val name: Identifier,
   ) : TypeName() {
-    override fun toString() = "$serviceName.{$name}"
+    override fun toString() = nameToString(
+      packageName = serviceName.packageName,
+      serviceName = serviceName.name,
+      typeName = name,
+    )
   }
 
   data class Tuple(

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/IoPackageNameTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/IoPackageNameTest.kt
@@ -3,8 +3,8 @@ package dev.wasmo.brevity.io
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import dev.wasmo.brevity.Identifier.Companion.Identifier
-import dev.wasmo.brevity.IoPackageName
 import dev.wasmo.brevity.PackageName
+import dev.wasmo.brevity.SemVer
 import kotlin.test.Test
 
 class IoPackageNameTest {
@@ -12,9 +12,25 @@ class IoPackageNameTest {
   fun `PackageName toString`() {
     assertThat(
       PackageName(
+        namespaces = listOf(Identifier("abc")),
+        names = listOf(Identifier("def")),
+      ).toString()
+    ).isEqualTo("abc:def")
+
+    assertThat(
+      PackageName(
         namespaces = listOf(Identifier("abc"), Identifier("def"), Identifier("ghi")),
         names = listOf(Identifier("jkl"), Identifier("mno"), Identifier("pqr")),
       ).toString()
     ).isEqualTo("abc:def:ghi:jkl/mno/pqr")
+
+    assertThat(
+      PackageName(
+        namespaces = listOf(Identifier("abc"), Identifier("def"), Identifier("ghi")),
+        names = listOf(Identifier("jkl"), Identifier("mno"), Identifier("pqr")),
+        version = SemVer("1.2.3")
+      ).toString()
+    ).isEqualTo("abc:def:ghi:jkl/mno/pqr@1.2.3")
   }
 }
+

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/IoServiceNameTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/IoServiceNameTest.kt
@@ -1,0 +1,72 @@
+package dev.wasmo.brevity.io
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.wasmo.brevity.Identifier
+import dev.wasmo.brevity.PackageName
+import dev.wasmo.brevity.SemVer
+import dev.wasmo.brevity.ServiceName
+import kotlin.test.Test
+
+class IoServiceNameTest {
+  @Test
+  fun `ServiceName toString`() {
+    assertThat(
+      ServiceName(
+        PackageName(
+          namespaces = listOf(Identifier.Identifier("abc")),
+          names = listOf(Identifier.Identifier("def")),
+        ),
+        name = Identifier.Identifier("ghi"),
+      ).toString(),
+    ).isEqualTo("abc:def/ghi")
+
+    assertThat(
+      ServiceName(
+        PackageName(
+          namespaces = listOf(Identifier.Identifier("abc")),
+          names = listOf(Identifier.Identifier("def")),
+          version = SemVer("1.2.3"),
+        ),
+        name = Identifier.Identifier("ghi"),
+      ).toString(),
+    ).isEqualTo("abc:def/ghi@1.2.3")
+
+    assertThat(
+      ServiceName(
+        PackageName(
+          namespaces = listOf(
+            Identifier.Identifier("abc"),
+            Identifier.Identifier("def"),
+            Identifier.Identifier("ghi"),
+          ),
+          names = listOf(
+            Identifier.Identifier("jkl"),
+            Identifier.Identifier("mno"),
+            Identifier.Identifier("pqr"),
+          ),
+        ),
+        name = Identifier.Identifier("stu"),
+      ).toString(),
+    ).isEqualTo("abc:def:ghi:jkl/mno/pqr/stu")
+
+    assertThat(
+      ServiceName(
+        PackageName(
+          namespaces = listOf(
+            Identifier.Identifier("abc"),
+            Identifier.Identifier("def"),
+            Identifier.Identifier("ghi"),
+          ),
+          names = listOf(
+            Identifier.Identifier("jkl"),
+            Identifier.Identifier("mno"),
+            Identifier.Identifier("pqr"),
+          ),
+          version = SemVer("1.2.3"),
+        ),
+        name = Identifier.Identifier("stu"),
+      ).toString(),
+    ).isEqualTo("abc:def:ghi:jkl/mno/pqr/stu@1.2.3")
+  }
+}

--- a/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/TypeNameTest.kt
+++ b/brevity-wit/src/jvmTest/kotlin/dev/wasmo/brevity/io/TypeNameTest.kt
@@ -1,0 +1,42 @@
+package dev.wasmo.brevity.io
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.wasmo.brevity.Identifier.Companion.Identifier
+import dev.wasmo.brevity.PackageName
+import dev.wasmo.brevity.SemVer
+import dev.wasmo.brevity.ServiceName
+import dev.wasmo.brevity.TypeName
+import kotlin.test.Test
+
+class TypeNameTest {
+  @Test
+  fun `TypeName toString`() {
+    assertThat(
+      TypeName.Declared(
+        serviceName = ServiceName(
+          PackageName(
+            namespaces = listOf(Identifier("abc").constrain()),
+            names = listOf(Identifier("def").constrain()),
+          ),
+          name = Identifier("ghi").constrain(),
+        ),
+        name = Identifier("jkl").constrain(),
+      ).toString(),
+    ).isEqualTo("abc:def/ghi.jkl")
+
+    assertThat(
+      TypeName.Declared(
+        serviceName = ServiceName(
+          PackageName(
+            namespaces = listOf(Identifier("abc").constrain()),
+            names = listOf(Identifier("def").constrain()),
+            version = SemVer("1.2.3"),
+          ),
+          name = Identifier("ghi").constrain(),
+        ),
+        name = Identifier("jkl").constrain(),
+      ).toString(),
+    ).isEqualTo("abc:def/ghi.jkl@1.2.3")
+  }
+}


### PR DESCRIPTION
From the docs, I found an example `wasi:http/types.headers`. Our syntax is currently `wasi:http/types.{headers}`.

This makes the editorial decision to put semver information at the end of type names. (It's always at the end of service names.)